### PR TITLE
fix to work on psp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ CHEAT_FILE := CHEAT.TXT
 $(CHEAT_FILE):
 	mkdir -p bin
 	armips src/src.asm
-	python gencwcheat.py
+	python3 gencwcheat.py
 
 modio:
 	if [ ! -d modio ]; then \

--- a/gencwcheat.py
+++ b/gencwcheat.py
@@ -1,4 +1,4 @@
-var = 142606588
+var = 142609660
 
 #from filewrappers import CWCheatFileDescriptor as cwcheatfd
 from cwcheatio import CwCheatIO
@@ -10,7 +10,7 @@ file = CwCheatIO("CHEATS.TXT")
 #file.write(b'\x4b\x00\x20\x0e')
 
 
-file.seek(0x8800000)
+file.seek(0x8800C00)
 
 file.write("Target Camera 1/3")
 with open("bin/CAMERA.bin", "rb") as bin:
@@ -20,7 +20,7 @@ file.write("Target Camera 2/3")
 
 file.write(
     "_L 0xD0000001 0x10000110\n"
-    "_L 0x200E5F88 0x0A200004\n"
+    "_L 0x200E5F88 0x0A200304\n"
     "_L 0x200E5F8C 0x00000000\n"
     
     "_L 0xD0000001 0x10000140\n"
@@ -51,7 +51,7 @@ file.write(
 )
 
 file.write("Target Camera UI 1/2")
-file.seek(0x08800A00)
+file.seek(0x08801600)
 with open("bin/RENDER.bin", "rb") as bin:
     file.write_once(bin.read())
 
@@ -61,6 +61,6 @@ file.write(
     "_L 0xE0036167 0x01457ca0\n"
     "_L 0xE002004b 0x11563adc\n"
 )
-file.write(b'\x80\x02\x20\x0a')
+file.write(b'\x80\x05\x20\x0a')
 file.write(b'\x00\x00\x00\x00')
 file.close()

--- a/src/src.asm
+++ b/src/src.asm
@@ -23,7 +23,7 @@ icon_y equ 225
 	sh			orig, value & 0xFFFF(at)
 .endmacro
 
-.createfile "./bin/CAMERA.bin", 0x8800000
+.createfile "./bin/CAMERA.bin", 0x8800C00
 	// constants
 .area 0x10, 0x0
 pi2:
@@ -78,23 +78,23 @@ magic:
 	
 	lui			a3, 0x880
 	
-	lv.s		s002, 0x00(a3)  ; loads 2/pi
+	lv.s		s002, 0xC00(a3)  ; loads 2/pi
 	vdiv.s		s003, s003, s002
 	vsgn.s		s001, s001
 	vmul.s		s003, s003, s001
 	
 	; angle is ready in radians
-	lv.s		s002, 0x04(a3)  ; loads pi
+	lv.s		s002, 0xC04(a3)  ; loads pi
 	vadd.s		s003, s003, s002
 	
-	lv.s		s002, 0x0C(a3)  ; loads 0
+	lv.s		s002, 0xC0C(a3)  ; loads 0
 	vsge.s		s000, s001, s002
 	
-	lv.s		s002, 0x04(a3)  ; loads pi
+	lv.s		s002, 0xC04(a3)  ; loads pi
 	vmul.s		s002, s000, s002
 	vadd.s		s003, s003, s002
 	
-	lv.s		s002, 0x08(a3)  ; loads mariana's constant
+	lv.s		s002, 0xC08(a3)  ; loads mariana's constant
 	vmul.s		s003, s003, s002
 	vf2in.s		s000, s003, 0x0
 	
@@ -141,7 +141,7 @@ selected_monster:
 
 .close
 
-.createfile "./bin/RENDER.bin", 0x08800A00
+.createfile "./bin/RENDER.bin", 0x08801600
 ;  ICON RENDERING
 
 .func render
@@ -166,6 +166,8 @@ selected_monster:
     nop
 
     li          a0, gpu_code
+    li          a2, 0
+    li          a3, 0
     jal         0x08960CF8; sceGeListEnQueue
     li          a1, 0x0
     


### PR DESCRIPTION
Addresses near `0x8800000` are used by PSP cheat plugins, and writing too close to them causes cheats to crash on the PSP. I moved the base address to `0x8800C00`, and it worked perfectly on both the PSP and PS Vita using Adrenaline and TempAR.